### PR TITLE
Use the latest version of Ruby 2.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: ruby:2.5.7
     steps:
       - checkout
+      - run: gem install bundler -v 1.17.3
       - run: bundle install
       - run: bundle exec rake
       - run: bundle exec rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   ruby-2.5:
     docker:
-      - image: ruby:2.5.1
+      - image: ruby:2.5.7
     steps:
       - checkout
       - run: bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.1.5
+  - 2.5.7
 before_install: gem install bundler -v 1.10.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
   - 2.5.7
-before_install: gem install bundler -v 1.10.6
+before_install: gem install bundler -v 1.17.3


### PR DESCRIPTION
# Why?
These commits aims to maintain the CI environments.

# Changes
- Use Ruby `2.5.7`
- Use Bundler `1.17.3` based on `BUNDLED_WITH` in "Gemfile.lock"

# Ref.
- https://www.ruby-lang.org/ja/news/2019/10/01/ruby-2-5-7-released/
- kufu/kirico@c6f1dea
- https://github.com/kufu/tsubaki/commit/b3d5d871f8fdee36a31a60d0a8e31a6bb5772b99#diff-e79a60dc6b85309ae70a6ea8261eaf95R112