### PR TITLE
Privatize unneededly protected methods

### DIFF
--- a/lib/tsubaki/matchers/validate_corporate_number_of_matcher.rb
+++ b/lib/tsubaki/matchers/validate_corporate_number_of_matcher.rb
@@ -59,7 +59,7 @@ module Tsubaki
           self
         end
 
-        protected
+        private
 
         def error_when_not_valid
           [error_test_allow_blank, error_test_strict, error_test_divider, error_test]
@@ -68,8 +68,6 @@ module Tsubaki
         def no_error_when_valid
           [no_error_test_allow_blank, no_error_test_strict, no_error_test_divider, no_error_test]
         end
-
-        private
 
         def valid_attribute_with?(value)
           dup_subject = @subject.dup

--- a/lib/tsubaki/matchers/validate_my_number_of_matcher.rb
+++ b/lib/tsubaki/matchers/validate_my_number_of_matcher.rb
@@ -59,7 +59,7 @@ module Tsubaki
           self
         end
 
-        protected
+        private
 
         def error_when_not_valid
           [error_test_allow_nil, error_test_strict, error_test_divider, error_test]
@@ -68,8 +68,6 @@ module Tsubaki
         def no_error_when_valid
           [no_error_test_allow_nil, no_error_test_strict, no_error_test_divider, no_error_test]
         end
-
-        private
 
         def valid_attribute_with?(value)
           dup_subject = @subject.dup


### PR DESCRIPTION
These `protected` keyword looks like unneededly, since they are not using explicit receiver.
Let it go under `private`.

See also:
- https://docs.ruby-lang.org/ja/2.5.0/doc/spec=2fdef.html#limit
- https://docs.ruby-lang.org/ja/2.5.0/method/Module/i/public.html
- https://docs.ruby-lang.org/ja/2.5.0/method/Module/i/protected.html
- https://docs.ruby-lang.org/ja/2.5.0/method/Module/i/private.html
- http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/7669
- https://blog.jnito.com/entry/20120315/1331754912
- https://blog.jnito.com/entry/20120504/1336080083