### PR TITLE
Stop supporting Ruby 2.4 :coffin:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,6 @@ executors:
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
-  ruby_2_4:
-    docker:
-      - image: rubylang/ruby:2.4-bionic
-        auth:
-          username: smarthrinc
-          password: $DOCKER_HUB_ACCESS_TOKEN
 
 commands:
   install_system_dependencies:
@@ -74,13 +68,6 @@ jobs:
       - checkout
       - bundle_gems
       - run_tests
-  run_tests_on_ruby_2_4:
-    executor: ruby_2_4
-    steps:
-      - install_system_dependencies
-      - checkout
-      - bundle_gems
-      - run_tests
 
 workflows:
   version: 2
@@ -89,4 +76,3 @@ workflows:
       - run_tests_on_ruby_2_7
       - run_tests_on_ruby_2_6
       - run_tests_on_ruby_2_5
-      - run_tests_on_ruby_2_4


### PR DESCRIPTION
Ruby 2.4 had been EOL (End Of Life). I think you don't need it, don't you?

# Ref.
- https://www.ruby-lang.org/en/downloads/branches/