### PR TITLE
Support `on` option

### DIFF
--- a/lib/tsubaki/matchers/validate_my_number_of_matcher.rb
+++ b/lib/tsubaki/matchers/validate_my_number_of_matcher.rb
@@ -8,8 +8,12 @@ module Tsubaki
       #
       # Example:
       #   describe User do
-      #     it { should validate_my_number_of(:digits)
+      #     it { should validate_my_number_of(:digits) }
       #     it { should validate_my_number_of(:digits).strict.with_divider('-') }
+      #   end
+      #
+      #   describe AnotherUser do
+      #     it { should validate_my_number_of(:digits).on(:create) }
       #   end
       def validate_my_number_of(attribute_name)
         ValidateMyNumberOfMatcher.new(attribute_name)
@@ -22,6 +26,7 @@ module Tsubaki
           @options[:strict] = nil
           @options[:divider] = nil
           @options[:allow_nil] = nil
+          @options[:on] = nil
           @failure_messages = []
         end
 
@@ -37,10 +42,11 @@ module Tsubaki
 
         def description
           result = 'ensure my number format'
-          result << " for #{@attribute_name}"
-          result << ' with   strict mode' if @options[:strict].present?
-          result << " with divider '#{@options[:divider]}'" if @options[:divider].present?
-          result << ' and allow nil' if @options[:allow_nil].present?
+          result += " for #{@attribute_name}"
+          result += ' with strict mode' if @options[:strict].present?
+          result += " with divider '#{@options[:divider]}'" if @options[:divider].present?
+          result += ' and allow blank' if @options[:allow_blank].present?
+          result += " on #{@options[:on]}" if @options[:on].present?
           result
         end
 
@@ -56,6 +62,11 @@ module Tsubaki
 
         def allow_nil(allow_nil = true)
           @options[:allow_nil] = allow_nil
+          self
+        end
+
+        def on(on)
+          @options[:on] = on
           self
         end
 

--- a/spec/tsubaki/corporate_number_validator_spec.rb
+++ b/spec/tsubaki/corporate_number_validator_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tsubaki/matchers/validate_corporate_number_of_matcher'
 
 describe Tsubaki::CorporateNumberValidator do
   describe 'validation w/o any options' do
@@ -85,6 +86,23 @@ describe Tsubaki::CorporateNumberValidator do
     end
     it 'should not be valid when :allow_blank option is set to false' do
       expect(TestCorporationAllowBlankFalse.new(corporate_number: nil)).not_to be_valid
+    end
+  end
+
+  describe '#on' do
+    let(:matcher) do
+      Tsubaki::Shoulda::Matchers::ValidateCorporateNumberOfMatcher.new(:corporate_number)
+    end
+
+    it 'returns itself' do
+      expect(matcher.on(:some_context)).to eq(matcher)
+    end
+
+    it 'sets options[:on]' do
+      expect { matcher.on(:some_context) }
+        .to change { matcher.instance_variable_get(:@options)[:on] }
+        .from(nil)
+        .to(:some_context)
     end
   end
 end

--- a/spec/tsubaki/my_number_validator_spec.rb
+++ b/spec/tsubaki/my_number_validator_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tsubaki/matchers/validate_my_number_of_matcher'
 
 describe Tsubaki::MyNumberValidator do
   describe 'validation w/o any options' do
@@ -87,6 +88,23 @@ describe Tsubaki::MyNumberValidator do
     end
     it 'should not be valid when :allow_blank option is set to false' do
       expect(TestUserAllowBlankFalse.new(my_number: nil)).not_to be_valid
+    end
+  end
+
+  describe '#on' do
+    let(:matcher) do
+      Tsubaki::Shoulda::Matchers::ValidateMyNumberOfMatcher.new(:my_number)
+    end
+
+    it 'returns itself' do
+      expect(matcher.on(:some_context)).to eq(matcher)
+    end
+
+    it 'sets options[:on]' do
+      expect { matcher.on(:some_context) }
+        .to change { matcher.instance_variable_get(:@options)[:on] }
+        .from(nil)
+        .to(:some_context)
     end
   end
 end


### PR DESCRIPTION
it would be great if `ValidateCorporateNumberOfMatcher` and `ValidateMyNumberOfMatcher` work with `on` option.
so I made some changes to support it.

https://guides.rubyonrails.org/active_record_validations.html#on

note that thoughtbot/shoulda-matchers also supports it:
https://github.com/thoughtbot/shoulda-matchers/blob/main/lib/shoulda/matchers/active_model/validate_presence_of_matcher.rb#L81-L101