### PR TITLE
Test with maintained Ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,12 @@ version: 2.1
 
 executors:
   working_directory: /root/tsubaki
+  ruby_3_1:
+    docker:
+      - image: rubylang/ruby:3.1-focal
+        auth:
+          username: smarthrinc
+          password: $DOCKER_HUB_ACCESS_TOKEN
   ruby_3_0:
     docker:
       - image: rubylang/ruby:3.0-focal
@@ -11,18 +17,6 @@ executors:
   ruby_2_7:
     docker:
       - image: rubylang/ruby:2.7-bionic
-        auth:
-          username: smarthrinc
-          password: $DOCKER_HUB_ACCESS_TOKEN
-  ruby_2_6:
-    docker:
-      - image: rubylang/ruby:2.6-bionic
-        auth:
-          username: smarthrinc
-          password: $DOCKER_HUB_ACCESS_TOKEN
-  ruby_2_5:
-    docker:
-      - image: rubylang/ruby:2.5-bionic
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
@@ -53,6 +47,13 @@ commands:
             bundle exec rubocop
 
 jobs:
+  run_tests_on_ruby_3_1:
+    executor: ruby_3_1
+    steps:
+      - install_system_dependencies
+      - checkout
+      - bundle_gems
+      - run_tests
   run_tests_on_ruby_3_0:
     executor: ruby_3_0
     steps:
@@ -67,30 +68,14 @@ jobs:
       - checkout
       - bundle_gems
       - run_tests
-  run_tests_on_ruby_2_6:
-    executor: ruby_2_6
-    steps:
-      - install_system_dependencies
-      - checkout
-      - bundle_gems
-      - run_tests
-  run_tests_on_ruby_2_5:
-    executor: ruby_2_5
-    steps:
-      - install_system_dependencies
-      - checkout
-      - bundle_gems
-      - run_tests
 
 workflows:
   version: 2
   test:
     jobs:
+      - run_tests_on_ruby_3_1:
+          context: smarthr-dockerhub
       - run_tests_on_ruby_3_0:
           context: smarthr-dockerhub
       - run_tests_on_ruby_2_7:
-          context: smarthr-dockerhub
-      - run_tests_on_ruby_2_6:
-          context: smarthr-dockerhub
-      - run_tests_on_ruby_2_5:
           context: smarthr-dockerhub


### PR DESCRIPTION
I think it would be time to remove EOL Ruby versions and add the latest normal maintenance Ruby version, in the CircleCI config.

Refs.
- https://www.ruby-lang.org/en/downloads/branches/