### PR TITLE
Remove Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.5.7
-before_install: gem install bundler -v 1.17.3


### PR DESCRIPTION
We've transitioned to using GitHub Actions for our CI process, making the Travis CI configuration obsolete. I've removed the unnecessary Travis CI settings. Related PR: #28